### PR TITLE
fix: ostree.linux label should not be quoted

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -162,7 +162,7 @@ jobs:
             org.opencontainers.image.title=${{ matrix.kernel_flavor }} cached kernel
             org.opencontainers.image.description=A caching layer for kernels. Contains ${{ matrix.kernel_flavor }} kernel.
             org.opencontainers.image.version=${{ env.kernel_release}}.${{ env.date }}
-            ostree.linux="${{ env.kernel_release }}"
+            ostree.linux=${{ env.kernel_release }}
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository }}/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
 


### PR DESCRIPTION
This removes the improper quotes on `ostree.linux` image label. Important for downstreams consumption of the image.