### PR TITLE
fix: signing key must be used on 'schedule' events

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -167,7 +167,7 @@ jobs:
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/1728152?s=200&v=4
 
       - name: Retrieve Signing Key
-        if: github.event_name == 'scheduled' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group'
         shell: bash
         run: |
           mkdir -p certs


### PR DESCRIPTION
Typo, had `scheduled` instead of `schedule`.
