### PR TITLE
fix: Don't download kernel-headers for fsync kernel

### DIFF
--- a/fetch.sh
+++ b/fetch.sh
@@ -71,10 +71,10 @@ else
 
 fi
 
-if [[ "${kernel_flavor}" =~ fsync ]]; then
-    dnf download -y \
-        kernel-headers-"${kernel_version}"
-fi
+#if [[ "${kernel_flavor}" =~ fsync ]]; then
+#    dnf download -y \
+#        kernel-headers-"${kernel_version}"
+#fi
 
 if [[ ! -s /tmp/certs/private_key.priv ]]; then
     echo "WARNING: Using test signing key."


### PR DESCRIPTION
No longer being built(?)

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
