### PR TITLE
chore(ci): handle varied kernel releases for coreos

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -83,11 +83,11 @@ jobs:
               kernel_rel="$kernel_rel_part.fc${{ matrix.fedora_version }}"
               kernel_version="$major_minor_patch-$kernel_rel.$arch"
               URL="https://kojipkgs.fedoraproject.org/packages/kernel/"$major_minor_patch"/"$kernel_rel"/"$arch"/kernel-"$kernel_version".rpm"
-              echo "Looking for ${coreos_version} kernel: $kernel_version"
+              echo "Querying koji for ${coreos_version} kernel: $kernel_version"
               echo "$URL"
               HTTP_RESP=$(curl -sI "$URL" | grep ^HTTP)
               if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
-                echo "Failed to find $coreos_version kernel: $kernel_version"
+                echo "Koji failed to find $coreos_version kernel: $kernel_version"
                 case "$kernel_rel_part" in
                   "300")
                     kernel_rel_part="200"
@@ -104,15 +104,15 @@ jobs:
                 kernel_rel="$kernel_rel_part.fc${{ matrix.fedora_version }}"
                 kernel_version="$major_minor_patch-$kernel_rel.$arch"
                 URL="https://kojipkgs.fedoraproject.org/packages/kernel/"$major_minor_patch"/"$kernel_rel"/"$arch"/kernel-"$kernel_version".rpm"
-                echo "Retrying ${coreos_version} kernel: $kernel_version"
+                echo "Re-querying koji for ${coreos_version} kernel: $kernel_version"
                 echo "$URL"
                 HTTP_RESP=$(curl -sI "$URL" | grep ^HTTP)
                 if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
-                  echo "Kernel $kernel_version not found on Koji"
+                  echo "Koji failed to find $coreos_version kernel: $kernel_version"
                 fi
               fi
               if grep -q "200 OK" <<< "${HTTP_RESP}"; then
-                linux=$image_linux
+                linux=$kernel_version
               fi
             }
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -73,6 +73,45 @@ jobs:
               $dnf install -y dnf-plugins-core
             fi
 
+            coreos_kernel () {
+              coreos_version=${1}
+              image_linux=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:${coreos_version} | jq -r '.Labels["ostree.linux"]')
+              major_minor_patch=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+')
+              kernel_rel_part=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+\-\K([123][0]{2})')
+              arch=$(echo $image_linux | grep -oP 'fc\d+\.\K.*$')
+
+              kernel_rel="$kernel_rel_part.fc$fedora_version"
+              kernel_version="$major_minor_patch-$kernel_rel.$arch"
+              URL="https://kojipkgs.fedoraproject.org/packages/kernel/"$major_minor_patch"/"$kernel_rel"/"$arch"/kernel-"$kernel_version".rpm"
+              HTTP_RESP=$(curl -sI "$URL" | grep ^HTTP)
+              if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
+                echo "Failed to find stable kernel: $kernel_version"
+                case "$kernel_rel_part" in
+                  "300")
+                    kernel_rel="200.fc$fedora_version"
+                    ;;
+                  "200")
+                    kernel_rel="100.fc$fedora_version"
+                    ;;
+                  "100")
+                    ;;
+                  *)
+                    echo "unexpected kernel_rel_part ${kernel_rel_part}"
+                    ;;
+                esac
+                kernel_version="$major_minor_patch-$kernel_rel.$arch"
+                echo "Retrying stable kernel: $kernel_version"
+                URL="https://kojipkgs.fedoraproject.org/packages/kernel/"$major_minor_patch"/"$kernel_rel"/"$arch"/kernel-"$kernel_version".rpm"
+                HTTP_RESP=$(curl -sI "$URL" | grep ^HTTP)
+                if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
+                  echo "Kernel $kernel_version not found on Koji"
+                fi
+              fi
+              if grep -q "200 OK" <<< "${HTTP_RESP}"; then
+                linux=$image_linux
+              fi
+            }
+
             case ${{ matrix.kernel_flavor }} in
               "asus")
                 $dnf copr enable -y lukenukem/asus-kernel
@@ -90,15 +129,10 @@ jobs:
                 linux=$(skopeo inspect docker://quay.io/fedora-ostree-desktops/base:${{ matrix.fedora_version }} | jq -r '.Labels["ostree.linux"]' )
                 ;;
               "coreos-stable")
-                linux=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:stable | jq -r '.Labels["ostree.linux"]' )
-                coreos_fedora_version=$(echo $linux | grep -oP 'fc\K[0-9]+')
-                if [[ "${{ matrix.fedora_version }}" != "$coreos_fedora_version" ]]; then
-                   major_minor_patch=$(echo $linux | cut -d - -f 1)
-                   linux="${major_minor_patch}-200.fc${{ matrix.fedora_version }}.$(uname -m)"
-                fi
+                coreos_kernel stable
                 ;;
               "coreos-testing")
-                linux=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:testing | jq -r '.Labels["ostree.linux"]' )
+                coreos_kernel testing
                 ;;
               *)
                 echo "unexpected kernel_flavor '${{ matrix.kernel_flavor }}' for query"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -80,18 +80,20 @@ jobs:
               kernel_rel_part=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+\-\K([123][0]{2})')
               arch=$(echo $image_linux | grep -oP 'fc\d+\.\K.*$')
 
-              kernel_rel="$kernel_rel_part.fc$fedora_version"
+              kernel_rel="$kernel_rel_part.fc${{ matrix.fedora_version }}"
               kernel_version="$major_minor_patch-$kernel_rel.$arch"
               URL="https://kojipkgs.fedoraproject.org/packages/kernel/"$major_minor_patch"/"$kernel_rel"/"$arch"/kernel-"$kernel_version".rpm"
+              echo "Looking for ${coreos_version} kernel: $kernel_version"
+              echo "$URL"
               HTTP_RESP=$(curl -sI "$URL" | grep ^HTTP)
               if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
-                echo "Failed to find stable kernel: $kernel_version"
+                echo "Failed to find $coreos_version kernel: $kernel_version"
                 case "$kernel_rel_part" in
                   "300")
-                    kernel_rel="200.fc$fedora_version"
+                    kernel_rel_part="200"
                     ;;
                   "200")
-                    kernel_rel="100.fc$fedora_version"
+                    kernel_rel_part="100"
                     ;;
                   "100")
                     ;;
@@ -99,9 +101,11 @@ jobs:
                     echo "unexpected kernel_rel_part ${kernel_rel_part}"
                     ;;
                 esac
+                kernel_rel="$kernel_rel_part.fc${{ matrix.fedora_version }}"
                 kernel_version="$major_minor_patch-$kernel_rel.$arch"
-                echo "Retrying stable kernel: $kernel_version"
                 URL="https://kojipkgs.fedoraproject.org/packages/kernel/"$major_minor_patch"/"$kernel_rel"/"$arch"/kernel-"$kernel_version".rpm"
+                echo "Retrying ${coreos_version} kernel: $kernel_version"
+                echo "$URL"
                 HTTP_RESP=$(curl -sI "$URL" | grep ^HTTP)
                 if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
                   echo "Kernel $kernel_version not found on Koji"


### PR DESCRIPTION
This changes the workflow to check CoreOS kernel package expectations against koji before deciding the selected kernel version is valid.

Fixes: #20 


