### PR TITLE
feat: enable Fedora 41 builds

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -69,6 +69,7 @@ jobs:
           attempt_limit: 3
           attempt_delay: 15000
           command: |
+            set -euox pipefail
             if [[ ${{ matrix.kernel_flavor }} =~ asus|fsync|fsync-ba|surface ]]; then
               container_name="fq-$(uuidgen)"
               dnf="podman exec $container_name dnf"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -47,6 +47,16 @@ jobs:
             kernel_flavor: fsync
           - fedora_version: 39
             kernel_flavor: fsync-ba
+          - fedora_version: 41
+            kernel_flavor: fsync
+          - fedora_version: 41
+            kernel_flavor: fsync-ba
+          - fedora_version: 41
+            kernel_flavor: coreos-stable
+          - fedora_version: 41
+            kernel_flavor: coreos-testing
+          - fedora_version: 41
+            kernel_flavor: surface
 
     steps:
       - name: Checkout Push to Registry action

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -91,6 +91,7 @@ jobs:
               echo "Querying koji for ${coreos_version} kernel: $kernel_version"
               echo "$URL"
               HTTP_RESP=$(curl -sI "$URL" | grep ^HTTP)
+              linux=""
               if grep -qv "200 OK" <<< "${HTTP_RESP}"; then
                 echo "Koji failed to find $coreos_version kernel: $kernel_version"
                 case "$kernel_rel_part" in

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -37,6 +37,7 @@ jobs:
         fedora_version:
           - 39
           - 40
+          - 41
         exclude:
           - fedora_version: 39
             kernel_flavor: asus

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -69,7 +69,6 @@ jobs:
           attempt_limit: 3
           attempt_delay: 15000
           command: |
-            set -euox pipefail
             if [[ ${{ matrix.kernel_flavor }} =~ asus|fsync|fsync-ba|surface ]]; then
               container_name="fq-$(uuidgen)"
               dnf="podman exec $container_name dnf"

--- a/fetch.sh
+++ b/fetch.sh
@@ -93,6 +93,7 @@ openssl x509 -in /tmp/certs/public_key.der -out /tmp/certs/public_key.crt
 install -Dm644 /tmp/certs/public_key.crt "$PUBLIC_KEY_PATH"
 install -Dm644 /tmp/certs/private_key.priv "$PRIVATE_KEY_PATH"
 
+ls -la /
 if [[ "${kernel_flavor}" =~ asus|fsync|fsync-ba ]]; then
     dnf install -y \
         /kernel-"$kernel_version".rpm \

--- a/fetch.sh
+++ b/fetch.sh
@@ -154,9 +154,11 @@ if [[ ${DUAL_SIGN:-} == "true" ]]; then
     rm -f "$SECOND_PRIVATE_KEY_PATH" "$SECOND_PUBLIC_KEY_PATH"
 fi
 
+ln -s / /tmp/buildroot
+
 # Rebuild RPMs and Verify
 if [[ "${kernel_flavor}" =~ surface ]]; then
-    rpmrebuild --additional=--noprep --batch kernel-surface-core-"${kernel_version}"
+    rpmrebuild --additional=--buildroot=/tmp/buildroot --batch kernel-surface-core-"${kernel_version}"
     rm -f /usr/lib/modules/"${kernel_version}"/vmlinuz
     dnf reinstall -y \
         /kernel-surface-"$kernel_version".rpm \
@@ -165,7 +167,7 @@ if [[ "${kernel_flavor}" =~ surface ]]; then
         /kernel-surface-modules-extra-"$kernel_version".rpm \
         /root/rpmbuild/RPMS/"$(uname -m)"/kernel-*.rpm
 else
-    rpmrebuild --additional=--noprep --batch kernel-core-"${kernel_version}"
+    rpmrebuild --additional=--buildroot=/tmp/buildroot --batch kernel-core-"${kernel_version}"
     rm -f /usr/lib/modules/"${kernel_version}"/vmlinuz
     dnf reinstall -y \
         /kernel-"$kernel_version".rpm \

--- a/fetch.sh
+++ b/fetch.sh
@@ -5,7 +5,7 @@ set -eoux pipefail
 kernel_version="${KERNEL_VERSION}"
 kernel_flavor="${KERNEL_FLAVOR}"
 
-#CoreOS pool repo
+# CoreOS pool repo
 # curl -LsSf -o /etc/yum.repos.d/fedora-coreos-pool.repo \
 #     https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-coreos-pool.repo
 
@@ -58,20 +58,19 @@ elif [[ "${kernel_flavor}" == "surface" ]]; then
         libwacom-surface \
         libwacom-surface-data
 
-
 else
     KERNEL_MAJOR_MINOR_PATCH=$(echo "$kernel_version" | cut -d '-' -f 1)
     KERNEL_RELEASE="$(echo "$kernel_version" | cut -d - -f 2 | cut -d . -f 1).$(echo "$kernel_version" | cut -d - -f 2 | cut -d . -f 2)"
     ARCH=$(uname -m)
-    dnf download -y \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-core-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-extra-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-devel-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-devel-matched-"$kernel_version".rpm \
-        https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-uki-virt-"$kernel_version".rpm
-
+    
+    # Using curl instead of dnf download for https links
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-core-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-modules-extra-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-devel-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-devel-matched-"$kernel_version".rpm
+    curl -LO https://kojipkgs.fedoraproject.org//packages/kernel/"$KERNEL_MAJOR_MINOR_PATCH"/"$KERNEL_RELEASE"/"$ARCH"/kernel-uki-virt-"$kernel_version".rpm
 fi
 
 if [[ "${kernel_flavor}" =~ fsync|fsync-ba ]]; then

--- a/fetch.sh
+++ b/fetch.sh
@@ -156,7 +156,7 @@ fi
 
 # Rebuild RPMs and Verify
 if [[ "${kernel_flavor}" =~ surface ]]; then
-    rpmrebuild --batch kernel-surface-core-"${kernel_version}"
+    rpmrebuild --additional=--noprep --batch kernel-surface-core-"${kernel_version}"
     rm -f /usr/lib/modules/"${kernel_version}"/vmlinuz
     dnf reinstall -y \
         /kernel-surface-"$kernel_version".rpm \
@@ -165,7 +165,7 @@ if [[ "${kernel_flavor}" =~ surface ]]; then
         /kernel-surface-modules-extra-"$kernel_version".rpm \
         /root/rpmbuild/RPMS/"$(uname -m)"/kernel-*.rpm
 else
-    rpmrebuild --batch kernel-core-"${kernel_version}"
+    rpmrebuild --additional=--noprep --batch kernel-core-"${kernel_version}"
     rm -f /usr/lib/modules/"${kernel_version}"/vmlinuz
     dnf reinstall -y \
         /kernel-"$kernel_version".rpm \


### PR DESCRIPTION
This is not a complete PR yet, it only adds the workflow to run on Fedora 41.  We still need to switch around the LATEST, STABLE and GTS labels to the new images before this is GA.