### PR TITLE
chore(ci): add a workflow to enforce removal of old images

### DIFF
--- a/.github/workflows/cleanup-old-images.yml
+++ b/.github/workflows/cleanup-old-images.yml
@@ -22,4 +22,3 @@ jobs:
           delete-orphaned-images: true
           keep-n-tagged: 7
           keep-n-untagged: 7
-          dry-run: true

--- a/.github/workflows/cleanup-old-images.yml
+++ b/.github/workflows/cleanup-old-images.yml
@@ -1,0 +1,25 @@
+name: Cleanup Old Images
+on:
+  schedule:
+    - cron: "15 0 * * *" # 0015 UTC everyday
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+
+jobs:
+  delete-older-than-90:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete Images Older Than 90 Days
+        uses: dataaxiom/ghcr-cleanup-action@v1.0.13
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: asus-kernel,bazzite-kernel,coreos-stable-kernel,coreos-testing-kernel,fsync-ba-kernel,fsync-kernel,main-kernel,surface-kernel
+          older-than: 90 days
+          delete-orphaned-images: true
+          keep-n-tagged: 7
+          keep-n-untagged: 7
+          dry-run: true

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '.github/workflows/cleanup*.yml'
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}


### PR DESCRIPTION
GitHub policy is they will remove our packages older than 90 days, but they don't actually.

This workflow will self-enforce that to provide confidence that we won't rely on things which may start disappearing sometime.


This workflow has been tested in my personal repo for some time and I worked with the action maintainer to improve it.

Should be good to go to run here, as our ublue-os test case before expanding to other repos.