### PR TITLE
fix: unpin coreos kernel

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -97,10 +97,10 @@ jobs:
             coreos_kernel () {
               coreos_version=${1}
               image_linux=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:${coreos_version} | jq -r '.Labels["ostree.linux"]')
-# Pin a kernel here, gross workaround TODO: Make this cleaner
-#              if [[ "${{ matrix.kernel_flavor }}" == "coreos-stable" ]]; then
-#                image_linux="6.11.3-300.fc41.x86_64"
-#              fi
+              # Pin a kernel here, gross workaround TODO: Make this cleaner
+              # if [[ "${{ matrix.kernel_flavor }}" == "coreos-stable" ]]; then
+              #    image_linux="6.11.3-300.fc41.x86_64"
+              # fi
               major_minor_patch=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+')
               kernel_rel_part=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+\-\K([123][0]{2})')
               arch=$(echo $image_linux | grep -oP 'fc\d+\.\K.*$')

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -97,10 +97,6 @@ jobs:
             coreos_kernel () {
               coreos_version=${1}
               image_linux=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:${coreos_version} | jq -r '.Labels["ostree.linux"]')
-              # Gross Pin... But workaround coreos-stable being on a broken kernel...
-              if [[ "${{ matrix.kernel_flavor }}" == "coreos-stable" ]]; then
-                image_linux="6.11.3-300.fc41.x86_64"
-              fi
               major_minor_patch=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+')
               kernel_rel_part=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+\-\K([123][0]{2})')
               arch=$(echo $image_linux | grep -oP 'fc\d+\.\K.*$')

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -97,6 +97,10 @@ jobs:
             coreos_kernel () {
               coreos_version=${1}
               image_linux=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:${coreos_version} | jq -r '.Labels["ostree.linux"]')
+# Pin a kernel here, gross workaround TODO: Make this cleaner
+#              if [[ "${{ matrix.kernel_flavor }}" == "coreos-stable" ]]; then
+#                image_linux="6.11.3-300.fc41.x86_64"
+#              fi
               major_minor_patch=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+')
               kernel_rel_part=$(echo $image_linux | grep -oP '^\d+\.\d+\.\d+\-\K([123][0]{2})')
               arch=$(echo $image_linux | grep -oP 'fc\d+\.\K.*$')


### PR DESCRIPTION
Unpin 6.11.3 for downstream images

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
