### PR TITLE
fix: pull main kernel version from base-atomic

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -152,7 +152,11 @@ jobs:
                 linux=$($dnf repoquery --repoid linux-surface --whatprovides kernel-surface | sort -V | tail -n1 | sed 's/.*://')
                 ;;
               "main")
-                linux=$(skopeo inspect docker://quay.io/fedora-ostree-desktops/base-atomic:${{ matrix.fedora_version }} | jq -r '.Labels["ostree.linux"]' )
+                base_image_name="base"
+                if [[ ${{ matrix.fedora_version }} > 40 ]]; then
+                  base_image_name+="-atomic"
+                fi
+                linux=$(skopeo inspect docker://quay.io/fedora-ostree-desktops/$base_image_name:${{ matrix.fedora_version }} | jq -r '.Labels["ostree.linux"]' )
                 ;;
               "coreos-stable")
                 coreos_kernel stable

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -152,7 +152,7 @@ jobs:
                 linux=$($dnf repoquery --repoid linux-surface --whatprovides kernel-surface | sort -V | tail -n1 | sed 's/.*://')
                 ;;
               "main")
-                linux=$(skopeo inspect docker://quay.io/fedora-ostree-desktops/base:${{ matrix.fedora_version }} | jq -r '.Labels["ostree.linux"]' )
+                linux=$(skopeo inspect docker://quay.io/fedora-ostree-desktops/base-atomic:${{ matrix.fedora_version }} | jq -r '.Labels["ostree.linux"]' )
                 ;;
               "coreos-stable")
                 coreos_kernel stable


### PR DESCRIPTION
`quay.io/fedora-ostree-desktops/base` is no longer pushed to